### PR TITLE
add sabermod kernel toolchains

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -562,4 +562,9 @@
   <project path="tools/swt" name="platform/tools/swt" groups="notdefault,tools" remote="aosp" revision="refs/tags/android-5.0.2_r1" />
   <project path="vendor/candy5" name="vendor_candy" remote="candy" revision="c5" />
   <project path="vendor/cyngn" name="cyngn/android_vendor_cyngn" />
+  
+  <!-- SaberMod Kernel Toolchains -->
+    <project path="prebuilts/gcc/linux-x86/arm/arm-eabi-4.7-sm" name="UBERUTILS/arm-eabi-4.7" remote="github" revision="master" />
+  <project path="prebuilts/gcc/linux-x86/arm/arm-eabi-4.8-sm" name="UBERUTILS/arm-eabi-4.8" remote="github" revision="master" />
+  <project path="prebuilts/gcc/linux-x86/arm/arm-eabi-4.9-sm" name="UBERUTILS/arm-eabi-4.9" remote="github" revision="master" />
 </manifest>


### PR DESCRIPTION
to set the toolchain add these 2 lines to your BoardConfig.mk or BoardConfigCommon.mk for some. 4.9-sm will not work on all devices how ever 4.8-sm should so feel free to play around with it. currently I know m7's, m8 and otterx will work with 4.9


KERNEL_TOOLCHAIN := $(ANDROID_BUILD_TOP)/prebuilts/gcc/$(HOST_OS)-x86/arm/arm-eabi-4.9-sm/bin
KERNEL_TOOLCHAIN_PREFIX := arm-eabi-