### PR TITLE
Track Gello (c6)

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -110,9 +110,10 @@
   
   <!-- CM Projects -->
   <project path="external/mm-dash" name="android_external_mm-dash" remote="cm" revision="cm-13.0" />
+  <project path="packages/apps/Gello" name="android_packages_apps_Gello" remote="cm" revision="cm-13.0" />
   <project path="packages/apps/Snap" name="android_packages_apps_Snap" remote="cm" revision="cm-13.0" />
   <project path="external/ahbottomnavigation" name="android_external_ahbottomnavigation" remote="cm" revision="cm-13.0" />
-
+  
   <!-- OmniSwitch -->
   <project path="packages/apps/OmniSwitch" name="omnirom/android_packages_apps_OmniSwitch" remote="github" revision="android-6.0" />
   


### PR DESCRIPTION
Gello is a substitute to the default browser optimized for Qualcomm chipsets. It's completely up to the maintainer whether or not this gets used so there is absolutely no harm in tracking it.
