### PR TITLE
Readme: Update instructions to use https for repo init

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ You might want to take a look at @akhilnarang's scripts [here](https://github.co
 To initialize your local repository using the Candy c11 trees, use this command:
 
 
-    repo init -u git://github.com/CandyRoms/candy.git -b c11
+    repo init -u https://github.com/CandyRoms/candy.git -b c11
 
 
 Then sync up with this command:


### PR DESCRIPTION
HTTPS based repo init should be used since https://github.blog/2021-09-01-improving-git-protocol-security-github/